### PR TITLE
Fix blank preview

### DIFF
--- a/dotNET/PdfClown.Viewer/PdfClown.Viewer/PdfView.cs
+++ b/dotNET/PdfClown.Viewer/PdfClown.Viewer/PdfView.cs
@@ -43,11 +43,11 @@ namespace PdfClown.Viewer
         private float oldScale = 1;
         private float scale = 1;
         private readonly float indent = 10;
-        private SKMatrix CurrentWindowScaleMatrix;
-        private SKMatrix CurrentNavigationMatrix;
-        private SKMatrix CurrentPictureMatrix;
+        private SKMatrix CurrentWindowScaleMatrix = SKMatrix.MakeIdentity();
+        private SKMatrix CurrentNavigationMatrix = SKMatrix.MakeIdentity();
+        private SKMatrix CurrentPictureMatrix = SKMatrix.MakeIdentity();
         private SKPoint CurrentLocation;
-        private SKMatrix CurrentViewMatrix;
+        private SKMatrix CurrentViewMatrix = SKMatrix.MakeIdentity();
         private SKRect CurrentArea;
         private PdfPagePicture CurrentPicture;
 
@@ -57,7 +57,7 @@ namespace PdfClown.Viewer
         private SKRect currentAnnotationTextBounds;
         private SKPoint CurrentMoveLocation;
         private SKPoint? PressedCursorLocation;
-        private SKMatrix InvertPictureMatrix;
+        private SKMatrix InvertPictureMatrix = SKMatrix.MakeIdentity();
         public PdfView()
         {
             PaintContent += OnPaintContent;


### PR DESCRIPTION
Initialize matrices with identity matrix to trigger rendering of visible PDF area. Otherwise, only the scrollbar will signal the PDF was loaded but the preview would be blank.

Found while testing PdfClown.Viewer.Test.WPF.

BTW: Thank you for bringing this quite useful managed PDF rendering engine forward!

PS: I have some other branches I will share with you (FreeType fallback for Type1 fonts and Soft-Masks).
PPS: Would you mind enabling the "Issues" tab in this repository?