### PR TITLE
Smooth clipping paths even if rotated

### DIFF
--- a/dotNET/PdfClown/Documents/Contents/Objects/ModifyClipPath.cs
+++ b/dotNET/PdfClown/Documents/Contents/Objects/ModifyClipPath.cs
@@ -80,7 +80,7 @@ namespace PdfClown.Documents.Contents.Objects
             if (pathObject != null)
             {
                 pathObject.FillType = clipMode.ToSkia();
-                scanner.RenderContext.ClipPath(pathObject, SKClipOperation.Intersect);
+                scanner.RenderContext.ClipPath(pathObject, SKClipOperation.Intersect, true);
             }
         }
         #endregion


### PR DESCRIPTION
If clipping paths are not rendered with **antialiasing** enabled, **_rotated_ clipping paths** will render with **jagged edges**.

Test PDF:  
https://moemax.a.bigcontent.io/v1/static/NC37aBAl3v_Ri0rB6tsCJfzQ

Before:
![image](https://user-images.githubusercontent.com/886232/71450240-4b2ef880-275e-11ea-9c97-02897e2edb26.png)

After:
![image](https://user-images.githubusercontent.com/886232/71450241-51bd7000-275e-11ea-9b93-b2f8e1cf2317.png)

PS: the black box around is because of missing SMask support