### PR TITLE
Support SMask with ImageXObject and FormXObject

### DIFF
--- a/dotNET/PdfClown/Documents/Contents/ExtGState.cs
+++ b/dotNET/PdfClown/Documents/Contents/ExtGState.cs
@@ -101,9 +101,40 @@ namespace PdfClown.Documents.Contents
                 { state.BlendMode = BlendMode; }
                 else if (parameterName.Equals(PdfName.Type))
                 { }
+                else if (parameterName.Equals(PdfName.SMask))
+                {
+                    state.SMask = SMask;
+                }
                 //TODO:extend supported parameters!!!
             }
         }
+
+        [PDF(VersionEnum.PDF14)]
+        public PdfDictionary SMask
+        {
+            get
+            {
+                var sMask = BaseDataObject[PdfName.SMask];
+                if (sMask is PdfDictionary dict)
+                {
+                    return dict;
+                }
+                else if (sMask is PdfReference reference)
+                {
+                    return (PdfDictionary)reference.Resolve();
+                }
+                else if (sMask is PdfName name)
+                {
+                    return (PdfDictionary)BaseDataObject[name];
+                }
+                else
+                {
+                    throw new Exception($"Not Supported SMask: {sMask.GetType().Name}!");
+                }
+            }
+            set => BaseDataObject[PdfName.SMask] = value;
+        }
+
 
         /**
           <summary>Gets/Sets the blend mode to be used in the transparent imaging model [PDF:1.7:7.2.4].

--- a/dotNET/PdfClown/Documents/Contents/Scanner/GraphicsState.cs
+++ b/dotNET/PdfClown/Documents/Contents/Scanner/GraphicsState.cs
@@ -31,6 +31,7 @@ using System;
 using System.Collections.Generic;
 using SkiaSharp;
 using PdfClown.Documents.Contents.XObjects;
+using PdfClown.Objects;
 
 namespace PdfClown.Documents.Contents
 {
@@ -397,6 +398,7 @@ namespace PdfClown.Documents.Contents
 
         public double? StrokeAlpha { get; internal set; }
         public double? FillAlpha { get; internal set; }
+        public PdfDictionary SMask { get; internal set; }
 
         #endregion
 
@@ -431,6 +433,7 @@ namespace PdfClown.Documents.Contents
             strokeColorSpace = colors::DeviceGrayColorSpace.Default;
             TextState = new TextGraphicsState();
             wordSpace = 0;
+            SMask = null;
 
             // Rendering context initialization.
             Scanner.RenderContext?.SetMatrix(ctm);
@@ -481,6 +484,7 @@ namespace PdfClown.Documents.Contents
             state.strokeColorSpace = strokeColorSpace;
             state.TextState = textState;
             state.wordSpace = wordSpace;
+            state.SMask = SMask;
         }
 
 

--- a/dotNET/PdfClown/Documents/Contents/XObjects/FormXObject.cs
+++ b/dotNET/PdfClown/Documents/Contents/XObjects/FormXObject.cs
@@ -140,6 +140,14 @@ namespace PdfClown.Documents.Contents.XObjects
                 ;
         }
 
+        public PdfDictionary Group
+        {
+            get
+            {
+                return (PdfDictionary)BaseDataObject.Header.Resolve(PdfName.Group);
+            }
+        }
+
         public override SKSize Size
         {
             get


### PR DESCRIPTION
Support **SMask** with ImageXObject and FormXObject

I don't know if the place where I implemented the application of the SMask is the correct one (in `PaintXObject.cs`). If not, it should still provide enough inspiration for a clean version.

Test-PDF:  
https://moemax.a.bigcontent.io/v1/static/NC37aBAl3v_Ri0rB6tsCJfzQ

Before:
![image](https://user-images.githubusercontent.com/886232/71450574-a368f900-2764-11ea-887e-c35e9f6b1ffb.png)

After:
![image](https://user-images.githubusercontent.com/886232/71450575-aa900700-2764-11ea-8be8-a219c12f805b.png)
